### PR TITLE
Remove more log4 1.2 occurrences

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -446,6 +446,10 @@
            <groupId>org.apache.pdfbox</groupId>
            <artifactId>pdfbox</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+       </exclusion>
       </exclusions>
     </dependency>
 
@@ -537,6 +541,12 @@
       <groupId>org.owasp.esapi</groupId>
       <artifactId>esapi</artifactId>
       <version>2.3.0.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.xmlunit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -521,6 +521,10 @@
             <groupId>geronimo-spec</groupId>
             <artifactId>geronimo-spec-jms</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>
@@ -800,6 +804,10 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>
@@ -861,6 +869,10 @@
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
 
@@ -893,8 +905,8 @@
         <version>${metrics.version}</version>
         <exclusions>
            <exclusion>
-             <groupId>ch.qos.reload4j</groupId>
-             <artifactId>reload4j</artifactId>
+             <groupId>log4j</groupId>
+             <artifactId>log4j</artifactId>
            </exclusion>
         </exclusions>
       </dependency>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -360,6 +360,10 @@
           <groupId>org.apache.xmlgraphics</groupId>
           <artifactId>batik-transcoder</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 


### PR DESCRIPTION
With this commit log4j-1.2.17 is not present in the final WAR anymore.